### PR TITLE
Allow opening OpusFile/OpusFileStream from memory.

### DIFF
--- a/tests/test_opus_file.py
+++ b/tests/test_opus_file.py
@@ -1,6 +1,5 @@
 import pytest
 import pyogg
-import os
 
 from config import Config
 
@@ -86,3 +85,17 @@ def test_output_via_wav(pyogg_config: Config) -> None:
     wave_out.setsampwidth(opus_file.bytes_per_sample)
     wave_out.setframerate(opus_file.frequency)
     wave_out.writeframes(opus_file.buffer)
+
+
+def test_from_memory(pyogg_config: Config) -> None:
+    # Load the demonstration file that is exactly 5 seconds long
+    filename = str(
+        pyogg_config.rootdir
+        / "examples/left-right-demo-5s.opus"
+    )
+    # Load the file into memory, then into OpusFile.
+    with open(filename, "rb") as f:
+        from_memory = pyogg.OpusFile(f.read())
+    # For comparison, load the file directly with OpusFile.
+    from_file = pyogg.OpusFile(filename)
+    assert bytes(from_memory.buffer) == bytes(from_file.buffer)

--- a/tests/test_opus_file_stream.py
+++ b/tests/test_opus_file_stream.py
@@ -115,4 +115,31 @@ def test_same_data_as_opus_file_using_as_array(pyogg_config: Config):
 
     # Check that every byte is identical for both buffers
     assert numpy.all(buf_all == opus_file.as_array())
-    
+
+
+def test_from_memory(pyogg_config: Config) -> None:
+    # Load the demonstration file that is exactly 5 seconds long
+    filename = str(
+        pyogg_config.rootdir
+        / "examples/left-right-demo-5s.opus"
+    )
+
+    # Load the file into memory, then into OpusFileStream.
+    with open(filename, "rb") as f:
+        from_memory = pyogg.OpusFileStream(f.read())
+    # For comparison, load directly with OpusFile.
+    from_file = pyogg.OpusFileStream(filename)
+
+    # Loop through the OpusFileStreams until we've read all the data
+    while True:
+        # Read the next part of the stream
+        from_memory_buf = from_memory.get_buffer()
+        from_file_buf = from_file.get_buffer()
+
+        # Check if we've reached the end of the stream
+        if from_memory_buf is None or from_file_buf is None:
+            break
+        # Check that every byte is identical for both buffers
+        assert bytes(from_memory_buf) == bytes(from_file_buf)
+    # Check that we've reached the end of both streams
+    assert from_memory_buf is None and from_file_buf is None


### PR DESCRIPTION
Modifies `OpusFile`/`OpusFileStream`'s `__init__()` to accept a path or buffer and call the appropriate libopusfile function (`op_open_file` or `op_open_memory`, respectively).

Resolves #90.