### PR TITLE
Remove now dead code on `OggOpusWriter`

### DIFF
--- a/pyogg/ogg_opus_writer.py
+++ b/pyogg/ogg_opus_writer.py
@@ -57,7 +57,6 @@ class OggOpusWriter():
 
         # Create a packet (reused for each pass)
         self._ogg_packet = ogg.ogg_packet()
-        self._packet_valid = False
 
         # Create a page (reused for each pass)
         self._ogg_page = ogg.ogg_page()
@@ -173,14 +172,6 @@ class OggOpusWriter():
 
         # Flush the underlying buffered encoder
         self._write_to_oggopus(memoryview(bytearray(b"")), flush=True)
-
-        # The current packet must be the end of the stream, update
-        # the packet's details
-        self._ogg_packet.e_o_s = 1
-
-        # Write the packet to the stream
-        if self._packet_valid:
-            self._write_packet()
 
         # Flush the stream of any unwritten pages
         self._flush()


### PR DESCRIPTION
https://github.com/TeamPyOgg/PyOgg/commit/d2a59e04cd1df047694c4208c7d07bc6ba6316b4 left the `_packet_valid` field unused, and always set to `False`. Generating an EOS packet and page is now done by the encoder as part of the `_write_to_oggopus` invocation, so there is no need for any new packet writing logic on `close()` anymore.